### PR TITLE
.gitignore added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# executables
+3d/mjd_fieldgen3d
+3d/stester
+mass
+mjd_fieldgen
+stester
+
+# output files
+file.spe
+undepleted.txt
+fields/*.dat


### PR DESCRIPTION
Currently, The repository does not include .gitignore file. So executable and output files which are produced after the compilation and runs is being tracked which may make some problems during update or making pull requests.
